### PR TITLE
Settings: 코드래빗 설정파일 추가

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+language: 'ko-KR'
+early_access: false
+reviews:
+  profile: 'chill'
+  request_changes_workflow: false
+  high_level_summary: false
+  poem: false
+  review_status: false
+  collapse_walkthrough: false
+  sequence_diagrams: false
+  changed_files_summary: false
+  path_filters: ['!.github/**', '!dist/**', '!.src/**', '!./**']
+  auto_review:
+    enabled: false
+    drafts: false
+chat:
+  auto_reply: false


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

코드래빗 설정파일 추가

## 📋 작업 내용

language
'ko-KR'로 설정되어 있어, 시스템이나 앱이 한국어(대한민국)로 표시되도록 합니다.

early_access
false로 설정된 경우, 초기 액세스 기능이 비활성화됩니다. 초기 액세스 기능은 주로 베타 버전이나 새로운 기능을 사전 체험할 때 사용하는 옵션입니다.

reviews
리뷰에 관련된 다양한 옵션들이 포함되어 있으며, 세부 항목은 아래와 같습니다:

profile: 'chill'
리뷰의 성격을 'chill'로 설정하여 리뷰가 여유롭고 덜 엄격하게 진행될 수 있습니다.

request_changes_workflow: false
리뷰에서 변경 요청 워크플로우가 비활성화됩니다. 이 기능이 활성화되면 리뷰어가 코드 수정 요청을 할 때 워크플로우에 변경 요청이 표시됩니다.

high_level_summary: false
리뷰 요약이 제공되지 않습니다. 요약 제공이 비활성화되면 리뷰어가 고수준 요약을 작성하지 않아도 됩니다.

poem: false
리뷰에 시적인 표현이나 창의적인 리뷰 형식을 추가하지 않습니다.

review_status: false
리뷰 상태에 대한 표시가 비활성화됩니다. 리뷰 상태가 비활성화되면 리뷰 상태 변화가 표시되지 않습니다.

collapse_walkthrough: false
코드 설명을 축소하지 않습니다. 이 옵션을 활성화하면 코드 설명이 접혀서 요약된 형태로 보여집니다.

sequence_diagrams: false
시퀀스 다이어그램 생성이 비활성화됩니다. 코드 리뷰에서 프로세스나 흐름을 시각화하는 시퀀스 다이어그램을 생성하지 않습니다.

changed_files_summary: false
변경된 파일에 대한 요약을 제공하지 않습니다. 이 옵션을 활성화하면 리뷰에 변경된 파일 목록과 요약이 포함됩니다.

path_filters: ['!.github/**', '!dist/**', '!.src/**', '!./**']
리뷰 대상에서 제외할 파일 경로를 필터링합니다. 예를 들어, .github, dist, .src 폴더와 같은 특정 경로에 있는 파일은 리뷰에 포함되지 않습니다.

auto_review
자동 리뷰와 관련된 설정을 포함합니다:

enabled: false
자동 리뷰 기능을 비활성화합니다.

drafts: false
자동 리뷰 초안 기능을 비활성화합니다. 활성화 시 자동 리뷰 초안을 생성할 수 있습니다.

chat
auto_reply: false
자동 응답 기능을 비활성화합니다. 활성화되면 자동으로 응답 메시지를 전송할 수 있습니다.

