### PR TITLE
[fix] file 탭에서 등록해둔 파일명리스트가 edit탭 누르면 사라지는현상 수정

### DIFF
--- a/src/components/sidebar/TTSSidebar.tsx
+++ b/src/components/sidebar/TTSSidebar.tsx
@@ -3,8 +3,16 @@ import { Button } from '@/components/ui/button';
 import EditContent from '@/components/sidebar/sidebarContent/EditContent';
 import { FileContent } from '@/components/sidebar/sidebarContent/FileContent';
 
+interface IFileStatus {
+  name: string;
+  status: '완료' | '오류';
+}
+
 const TTSSidebar = () => {
   const [activeTab, setActiveTab] = useState<'file' | 'edit'>('file');
+  const [allFiles, setAllFiles] = useState<IFileStatus[]>([]); // 전체 업로드 시도된 파일 리스트
+  const [uploadedFiles, setUploadedFiles] = useState<string[]>([]); // 업로드 완료된 파일 리스트
+  const [uploadingCount, setUploadingCount] = useState<number>(0); // 현재 업로드 중인 파일 개수
 
   return (
     <>
@@ -25,7 +33,18 @@ const TTSSidebar = () => {
         </Button>
       </div>
       {/* 탭별 콘텐츠 */}
-      {activeTab === 'file' ? <FileContent /> : <EditContent />}
+      {activeTab === 'file' ? (
+        <FileContent
+          allFiles={allFiles}
+          setAllFiles={setAllFiles}
+          uploadedFiles={uploadedFiles}
+          setUploadedFiles={setUploadedFiles}
+          uploadingCount={uploadingCount}
+          setUploadingCount={setUploadingCount}
+        />
+      ) : (
+        <EditContent />
+      )}
     </>
   );
 };

--- a/src/components/sidebar/sidebarContent/FileContent.tsx
+++ b/src/components/sidebar/sidebarContent/FileContent.tsx
@@ -1,18 +1,30 @@
-import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { useTextInputs } from '@/stores/textInputStore';
 import { CircularProgress } from '@/components/ui/CircularProgress';
+import { useTextInputs } from '@/stores/textInputStore';
 
 interface IFileStatus {
   name: string;
-  status: '완료' | '오류'; // 완료 또는 오류 상태
+  status: '완료' | '오류';
 }
 
-export const FileContent = () => {
+interface IFileContentProps {
+  allFiles: IFileStatus[];
+  setAllFiles: React.Dispatch<React.SetStateAction<IFileStatus[]>>;
+  uploadedFiles: string[];
+  setUploadedFiles: React.Dispatch<React.SetStateAction<string[]>>;
+  uploadingCount: number;
+  setUploadingCount: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export const FileContent: React.FC<IFileContentProps> = ({
+  allFiles,
+  setAllFiles,
+  uploadedFiles,
+  setUploadedFiles,
+  uploadingCount,
+  setUploadingCount,
+}) => {
   const { addTextInputs } = useTextInputs();
-  const [allFiles, setAllFiles] = useState<IFileStatus[]>([]); // 전체 업로드 시도된 파일 리스트
-  const [uploadedFiles, setUploadedFiles] = useState<string[]>([]); // 업로드 완료된 파일 리스트
-  const [uploadingCount, setUploadingCount] = useState<number>(0); // 현재 업로드 중인 파일 개수
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

file 탭에서 등록해둔 파일명리스트가 edit탭 누르면 사라지는현상 수정

## 📋 작업 내용

file 탭에서 등록해둔 파일명리스트가 edit탭 누르면 사라지는현상 수정

## 🔧 변경 사항

file 탭에서 등록해둔 파일명리스트가 edit탭 누르면 사라지는현상 수정

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 파일 업로드 상태를 관리하고 표시하는 기능이 추가되었습니다.
	- `TTSSidebar`와 `FileContent` 컴포넌트 간의 데이터 전송이 개선되었습니다.
- **버그 수정**
	- 파일 업로드 처리 로직이 안정적으로 유지되어 오류 처리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->